### PR TITLE
libbdelta.cpp: tweak for c++11/gcc-6

### DIFF
--- a/src/libbdelta.cpp
+++ b/src/libbdelta.cpp
@@ -116,10 +116,7 @@ unsigned match_backward(BDelta_Instance *b, unsigned p1, unsigned p2, unsigned b
 
 // Iterator helper function
 template <class T>
-inline T prior(T i) {return --i;}
-template <class T>
-inline T next(T i) {return ++i;}
-
+static inline T bdelta_next(T i) {return ++i;}
 
 struct UnusedRange {
 	unsigned p, num;
@@ -421,7 +418,7 @@ void bdelta_pass(BDelta_Instance *b, unsigned blocksize, unsigned minMatchSize, 
 			UnusedRange u1 = unused[i], u2 = unused2[i];
 			if (u1.num >= blocksize && u2.num >= blocksize)
 				if (! maxHoleSize || (u1.num <= maxHoleSize && u2.num <= maxHoleSize))
-					if (! (flags & BDELTA_SIDES_ORDERED) || (next(u1.ml) == u1.mr && next(u2.ml) == u2.mr))
+					if (! (flags & BDELTA_SIDES_ORDERED) || (bdelta_next(u1.ml) == u1.mr && bdelta_next(u2.ml) == u2.mr))
 						bdelta_pass_2(b, blocksize, minMatchSize, &u1, 1, &u2, 1);
 		}
 	}


### PR DESCRIPTION
On bcc-6.2.0 build fails as:

```
    g++ -shared -fPIC -O2  libbdelta.cpp -o libbdelta.so
    libbdelta.cpp: In function 'void bdelta_pass(BDelta_Instance*, unsigned int, unsigned int, unsigned int, unsigned int)':
    libbdelta.cpp:424:57: error: call of overloaded 'next(std::__cxx11::list<Match>::iterator&)' is ambiguous
          if (! (flags & BDELTA_SIDES_ORDERED) || (next(u1.ml) == u1.mr && next(u2.ml) == u2.mr))
                                                             ^
    libbdelta.cpp:121:10: note: candidate: T next(T) [with T = std::_List_iterator<Match>]
     inline T next(T i) {return ++i;}
              ^~~~
    In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/6.2.0/include/g++-v6/bits/stl_algobase.h:66:0,
                     from /usr/lib/gcc/x86_64-pc-linux-gnu/6.2.0/include/g++-v6/list:60,
                     from libbdelta.cpp:18:
    /usr/lib/gcc/x86_64-pc-linux-gnu/6.2.0/include/g++-v6/bits/stl_iterator_base_funcs.h:205:5: note: candidate: _ForwardIterator std::next(_ForwardIterator, typename std::iterator_traits<_Iter>::difference_type) [with _ForwardIterator = std::_List_iterator<Match>; typename std::iterator_traits<_Iter>::difference_type = long int]
         next(_ForwardIterator __x, typename
         ^~~~
    libbdelta.cpp:424:81: error: call of overloaded 'next(std::__cxx11::list<Match>::iterator&)' is ambiguous
          if (! (flags & BDELTA_SIDES_ORDERED) || (next(u1.ml) == u1.mr && next(u2.ml) == u2.mr))
                                                                                     ^
    libbdelta.cpp:121:10: note: candidate: T next(T) [with T = std::_List_iterator<Match>]
     inline T next(T i) {return ++i;}
              ^~~~
    In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/6.2.0/include/g++-v6/bits/stl_algobase.h:66:0,
                     from /usr/lib/gcc/x86_64-pc-linux-gnu/6.2.0/include/g++-v6/list:60,
                     from libbdelta.cpp:18:
    /usr/lib/gcc/x86_64-pc-linux-gnu/6.2.0/include/g++-v6/bits/stl_iterator_base_funcs.h:205:5: note: candidate: _ForwardIterator std::next(_ForwardIterator, typename std::iterator_traits<_Iter>::difference_type) [with _ForwardIterator = std::_List_iterator<Match>; typename std::iterator_traits<_Iter>::difference_type = long int]
         next(_ForwardIterator __x, typename
         ^~~~
```

Basically it tells that next() comes both from std::
and from local scope (a c++11 addition):
    http://en.cppreference.com/w/cpp/iterator/next

Renamed helper to bdelta_next().

Reported-by: Toralf Förster
Bug: https://bugs.gentoo.org/594246
Signed-off-by: Sergei Trofimovich siarheit@google.com
